### PR TITLE
Adds component for an emoji

### DIFF
--- a/src/core/components/core-emoji.js
+++ b/src/core/components/core-emoji.js
@@ -1,0 +1,13 @@
+const Emoji = props => (
+	<span
+		className="emoji"
+		role="img"
+		aria-label={props.label ? props.label : ""}
+		aria-hidden={props.label ? "false" : "true"}
+	>
+		{props.symbol}
+	</span>
+);
+
+
+export default Emoji;


### PR DESCRIPTION
Example of using emoji component: 

Emoji symbol="😬" label="grimace"  --> (removed '<' '/<' component wrappers so it doesn't disappear. 

<img width="217" alt="Screen Shot 2021-04-17 at 8 05 34 PM" src="https://user-images.githubusercontent.com/44758803/115130225-bdfb5d00-9fbb-11eb-8ca2-54e24aef7c9b.png">
